### PR TITLE
Update matchmedia dependency to "~0.2.0"

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,6 +10,6 @@
   },
   "main": "./matchmedia-ng.js",
   "dependencies": {
-    "matchmedia": "~0.1.0"
+    "matchmedia": "~0.2.0"
   }
 }


### PR DESCRIPTION
I'm been using matchmedia-ng with matchmedia 0.2.0 and haven't seen any issues so far.
