### PR TITLE
Fix for IE9 "Object doesn't have method or property 'apply'"

### DIFF
--- a/matchmedia-ng.js
+++ b/matchmedia-ng.js
@@ -160,14 +160,14 @@ angular.module("matchmedia-ng", []).
             this.DEVMODE = devmode;
         };
 
-        this.$get = ['$window',function($window) {
+        this.$get = ['$window', '$log', function($window, $log) {
             var DEVMODE = this.DEVMODE;
             var logger = {};
             logger.log = function(){
-                if (DEVMODE) console.log.apply(console, arguments);
+                if (DEVMODE) $log.info(arguments);
             };
             logger.always = function(){
-                console.log.apply(console, arguments);
+                $log.info(arguments);
             };
             return logger;
         }];


### PR DESCRIPTION
console.log.apply causes an exception in IE9.  I switched to using $log instead of console.log, this fixed issues with IE 9 in my project.
