### PR TITLE
Add ajMatchmedia directive

### DIFF
--- a/matchmedia-ng.js
+++ b/matchmedia-ng.js
@@ -140,23 +140,24 @@ angular.module("matchmedia-ng", []).
         return {
             restrict: 'E',
             scope: {
+                'queryListener': '&',
                 'queryMatches': '='
             },
             link: function(scope, element, attrs, controllers) {
                 var deregister;
 
-                if (attrs.on) {
+                if (attrs.on && attrs.queryListener) {
                     if (attrs.on.slice(0, 2) === 'on' && matchmedia[attrs.on] !== 'undefined') {
                         deregister = matchmedia[attrs.on](function(mediaQueryList) {
-                            scope.queryMatches = mediaQueryList.matches;
+                            scope.queryListener({mediaQueryList: mediaQueryList});
                         });
                     } else {
                         deregister = matchmedia.on(attrs.on, function(mediaQueryList) {
-                            scope.queryMatches = mediaQueryList.matches;
+                            scope.queryListener({mediaQueryList: mediaQueryList});
                         });
                     }
                     scope.$on('$destroy', deregister);
-                } else if (attrs.is) {
+                } else if (attrs.is && attrs.queryMatches) {
                     if (attrs.is.slice(0, 2) === 'is' && matchmedia[attrs.is] !== 'undefined') {
                         scope.queryMatches = matchmedia[attrs.is]();
                     } else {


### PR DESCRIPTION
This adds a `<aj-matchmedia>` directive. Please note:
- As per the best practice described in the [AngularJS Directives Developer Guide](https://docs.angularjs.org/guide/directive#creating-directives), I chose `aj` (from AnalogJ) as the prefix.
- The `on` attribute is given priority over the `is` attribute.
- The aliases for both `on` and `is` are supported.
- With the `on` attribute present the supplied callback is called when the media query is evaluated again.
- With the `is` attribute present the result of the media query evaluation is being fed into `queryMatches`.

Example of usage:

``` html
<aj-matchmedia is="isTablet" query-matches="isTablet"></aj-matchmedia>
<div ng-show="isTablet">Content is shown when isTablet is true on pageload</div>
<aj-matchmedia on="onTablet" query-listener="onTablet(mediaQueryList)"></aj-matchmedia>
```

This fixes #8.
