### PR TITLE
The listener is added only if the browser supports it

### DIFF
--- a/matchmedia-ng.js
+++ b/matchmedia-ng.js
@@ -62,18 +62,21 @@ angular.module("matchmedia-ng", []).
              * @returns {function()} Returns a deregistration function for this listener.
              */
             matchmediaService.on = function(query, listener, $scope) {
-                logger.log('adding listener for query: '+ query);
-                var mediaQueryList = $window.matchMedia(query);
-                var handler = createSafeListener(listener, $scope);
-                mediaQueryList.addListener(handler);
-                //immediately return the current mediaQueryList;
-                handler(mediaQueryList);
+                var supportsMatchMedia = $window.matchMedia !== undefined && !!$window.matchMedia('').addListener;
+                if(supportsMatchMedia) {
+                    logger.log('adding listener for query: '+ query);
+                    var mediaQueryList = $window.matchMedia(query);
+                    var handler = createSafeListener(listener, $scope);
+                    mediaQueryList.addListener(handler);
+                    //immediately return the current mediaQueryList;
+                    handler(mediaQueryList);
 
-                return function() {
-                    logger.log('removing listener from query: '+ query);
-                    mediaQueryList.removeListener(handler);
+                    return function() {
+                        logger.log('removing listener from query: '+ query);
+                        mediaQueryList.removeListener(handler);
 
-                };
+                    };
+                }
             };
             /**
              * @param {string} query media query to test.


### PR DESCRIPTION
Fixes the issue Object doesn't support pro perty or method 'addListener' is the exact error. IE9 https://github.com/AnalogJ/matchmedia-ng/issues/7
