### PR TITLE
Fix overlapping matchmedia rules

### DIFF
--- a/matchmedia-ng.js
+++ b/matchmedia-ng.js
@@ -30,7 +30,7 @@ angular.module("matchmedia-ng", []).
                 screen : "screen",
                 phone : "(max-width: 767px)",
                 tablet : "(min-width: 768px) and (max-width: 979px)",
-                desktop : "(min-width: 979px)",
+                desktop : "(min-width: 980px)",
                 portrait : "(orientation: portrait)",
                 landscape : "(orientation: landscape)"
             }


### PR DESCRIPTION
Fixes the issue that tablet and desktop rules overlap at a browser width of 979px.