### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ The following is a comprehensive list of the media query aliases.
     matchmedia.isPortrait()
     matchmedia.isLandscape()
 
-###Override Aliases
+### Override Aliases
 It is possible to override the media queries given for the aliases above by using a `config` function.
 
 ```js


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
